### PR TITLE
Added secure random support for session ids that seem to be somehow cryp...

### DIFF
--- a/src/main/java/org/oneandone/idev/johanna/store/id/Identifier.java
+++ b/src/main/java/org/oneandone/idev/johanna/store/id/Identifier.java
@@ -21,6 +21,25 @@ public abstract class Identifier {
         return this.prefix;
     }
     
+    private final static int PREFIX_CHARS = 8;
+    
+    /** The prefix is defined to be always the first 8 chars.
+     * Keep this magic here if we want to change it.
+     * @return the prefix from the identifier.
+     */
+    protected static String prefixFrom(String identifier) {
+        // TODO IPv6
+        return identifier.substring(0, PREFIX_CHARS);
+    }
+    
+    /** The prefix is defined to be always the first 8 chars.
+     * Keep this magic here if we want to change it.
+     * @return the suffix from the identifier.
+     */
+    protected static String suffixFrom(String identifier) {
+        return identifier.substring(PREFIX_CHARS);
+    }    
+    
     @Override
     public String toString() {
         return this.prefix + this.uniqid();

--- a/src/main/java/org/oneandone/idev/johanna/store/id/IdentifierFactory.java
+++ b/src/main/java/org/oneandone/idev/johanna/store/id/IdentifierFactory.java
@@ -9,13 +9,24 @@ public enum IdentifierFactory {
 
         @Override
         public Identifier newIdentifier(String prefix) {
-            return new MD5Identifier(prefix);
+            return new SecureRandomIdentifier(prefix);
         }
 
         @Override
         public Identifier fromString(String id) {
-            return MD5Identifier.forId(id);
+            return SecureRandomIdentifier.forId(id);
         }
+    },
+    SECURERND {
+        @Override
+        public Identifier newIdentifier(String prefix) {
+            return new SecureRandomIdentifier(prefix);
+        }
+
+        @Override
+        public Identifier fromString(String id) {
+            return SecureRandomIdentifier.forId(id);
+        }        
     },
     UUID {
 

--- a/src/main/java/org/oneandone/idev/johanna/store/id/MD5Identifier.java
+++ b/src/main/java/org/oneandone/idev/johanna/store/id/MD5Identifier.java
@@ -13,9 +13,11 @@ import java.util.logging.Logger;
 import javax.xml.bind.DatatypeConverter;
 
 /**
- *
+ * @deprecated because Random is initialized with a constant seed, the MD5
+ * digests are predictable with O(1).
  * @author kiesel
  */
+@Deprecated()
 public class MD5Identifier extends Identifier {
     private static Random random;
 
@@ -39,8 +41,8 @@ public class MD5Identifier extends Identifier {
         Objects.requireNonNull(id);
         
         // TODO IPv6
-        MD5Identifier self= new MD5Identifier(id.substring(0, 8));
-        self.id= DatatypeConverter.parseHexBinary(id.substring(8));
+        MD5Identifier self= new MD5Identifier(prefixFrom(id));
+        self.id= DatatypeConverter.parseHexBinary(suffixFrom(id));
         
         return self;
     }
@@ -49,6 +51,8 @@ public class MD5Identifier extends Identifier {
         byte[] b32 = new byte[32];
         random.nextBytes(b32);
         
+        // TODO: calculating the digest out of a random number doesn't make a big
+        // difference if randomness is pseudo
         MessageDigest digest= MessageDigest.getInstance("md5");
         this.id= digest.digest(b32);
     }
@@ -67,6 +71,6 @@ public class MD5Identifier extends Identifier {
         if (null != random) return;
         
         // Length operation
-        random= new Random(0x80);
+        random= new Random(0x80); // BUG: this is the seed, not the length
     }
 }

--- a/src/main/java/org/oneandone/idev/johanna/store/id/SecureRandomIdentifier.java
+++ b/src/main/java/org/oneandone/idev/johanna/store/id/SecureRandomIdentifier.java
@@ -1,0 +1,62 @@
+package org.oneandone.idev.johanna.store.id;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.xml.bind.DatatypeConverter;
+
+/**
+ * Creates identifiers using {@link SecureRandom}.
+ * @author Stephan Fuhrmann
+ */
+public class SecureRandomIdentifier extends Identifier {
+    private static SecureRandom random = new SecureRandom();
+    
+    private final static int BYTESIZE = 16;
+    
+    static {
+        random = new SecureRandom();
+    }
+
+    private byte[] id;
+
+    public SecureRandomIdentifier(String prefix) {
+        super(prefix);
+        try {
+            this.createUniqid();
+        } catch (NoSuchAlgorithmException ex) {
+            Logger.getLogger(SecureRandomIdentifier.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+
+    SecureRandomIdentifier() {
+        this("");
+    }
+    
+    public static Identifier forId(String id) {
+        Objects.requireNonNull(id);
+        
+        SecureRandomIdentifier self= new SecureRandomIdentifier(prefixFrom(id));
+        self.id= DatatypeConverter.parseHexBinary(suffixFrom(id));
+        
+        return self;
+    }
+
+    private void createUniqid() throws NoSuchAlgorithmException {
+        byte[] b32 = new byte[BYTESIZE];
+        random.nextBytes(b32);
+        this.id= b32;
+    }
+
+    @Override
+    protected String uniqid() {
+        StringBuilder builder= new StringBuilder(BYTESIZE * 2);
+        
+        for (byte b : this.id) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
+    }
+}

--- a/src/main/java/org/oneandone/idev/johanna/store/id/UUIDIdentifier.java
+++ b/src/main/java/org/oneandone/idev/johanna/store/id/UUIDIdentifier.java
@@ -4,8 +4,10 @@ import java.util.UUID;
 
 /**
  *
+ * @deprecated there is pseudo generated randomness in UUID.randomUUID
  * @author kiesel
  */
+@Deprecated
 public class UUIDIdentifier extends Identifier {
     private final UUID id;
 
@@ -25,8 +27,8 @@ public class UUIDIdentifier extends Identifier {
     
     public static UUIDIdentifier forId(String id) {
         return new UUIDIdentifier(
-                id.substring(0, 8),
-                UUID.fromString(id.substring(8))
+                prefixFrom(id),
+                UUID.fromString(suffixFrom(id))
         );
     }
     

--- a/src/main/java/org/oneandone/idev/johanna/store/id/UUIDIdentifier.java
+++ b/src/main/java/org/oneandone/idev/johanna/store/id/UUIDIdentifier.java
@@ -4,10 +4,8 @@ import java.util.UUID;
 
 /**
  *
- * @deprecated there is pseudo generated randomness in UUID.randomUUID
  * @author kiesel
  */
-@Deprecated
 public class UUIDIdentifier extends Identifier {
     private final UUID id;
 

--- a/src/test/java/org/oneandone/idev/johanna/store/MD5IdentifierTest.java
+++ b/src/test/java/org/oneandone/idev/johanna/store/MD5IdentifierTest.java
@@ -4,9 +4,9 @@
  */
 package org.oneandone.idev.johanna.store;
 
-import org.oneandone.idev.johanna.store.id.MD5Identifier;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.oneandone.idev.johanna.store.id.MD5Identifier;
 
 /**
  *

--- a/src/test/java/org/oneandone/idev/johanna/store/SecureRandomIdentifierTest.java
+++ b/src/test/java/org/oneandone/idev/johanna/store/SecureRandomIdentifierTest.java
@@ -1,0 +1,36 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.oneandone.idev.johanna.store;
+
+import org.oneandone.idev.johanna.store.id.SecureRandomIdentifier;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @see SecureRandomIdentifier
+ * @author Stephan Fuhrmann
+ */
+public class SecureRandomIdentifierTest {
+    
+    public SecureRandomIdentifierTest() {
+    }
+    
+    /**
+     * Test of uniqid method, of class SecureRandomIdentifier.
+     */
+    @Test
+    public void uniqid_wo_prefix_is_32_chars() {
+        assertEquals(32, new SecureRandomIdentifier("").toString().length());
+    }
+    
+    /**
+     * 
+     */
+    @Test
+    public void check_prefix() {
+        assertEquals("hallo", new SecureRandomIdentifier("hallo").toString().substring(0, 5));
+    }
+}

--- a/src/test/java/org/oneandone/idev/johanna/store/SessionTest.java
+++ b/src/test/java/org/oneandone/idev/johanna/store/SessionTest.java
@@ -4,7 +4,7 @@
  */
 package org.oneandone.idev.johanna.store;
 
-import org.oneandone.idev.johanna.store.id.MD5Identifier;
+import org.oneandone.idev.johanna.store.id.SecureRandomIdentifier;
 import org.oneandone.idev.johanna.store.memory.Session;
 import java.text.ParseException;
 import java.util.Calendar;
@@ -26,7 +26,7 @@ public class SessionTest {
     
     @Before
     public void setUp() {
-        this.cut= new Session(new MD5Identifier(""));
+        this.cut= new Session(new SecureRandomIdentifier(""));
         this.cut.putValue("k", "v");
     }
     
@@ -35,7 +35,7 @@ public class SessionTest {
      */
     @Test
     public void testGetId() {
-        Session other= new Session(new MD5Identifier(""));
+        Session other= new Session(new SecureRandomIdentifier(""));
         assertNotEquals(this.cut.getId(), other.getId());
     }
 
@@ -113,7 +113,7 @@ public class SessionTest {
     
     @Test
     public void expires_next_day() throws ParseException {
-        Session s= new Session(new MD5Identifier(""), 86400);
+        Session s= new Session(new SecureRandomIdentifier(""), 86400);
         s.putValue("foo", "bar");
 
         Calendar today= new GregorianCalendar();


### PR DESCRIPTION
...tographically secure and unpredictable.

I've deprecated the MD5 identifier factory because they produce predictable identifiers. I've added a secure random identifier that is cryptographically robust.
Out of that I've moved the common code for extracting the 8-char-prefix to a common place for easier refactoring.

It's interesting on how to continue here: Pseudo randomness is usually not desired in session ids, but it may be ok for some usages. 